### PR TITLE
Adds check if folder exist before copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,11 +148,22 @@ var readContents = function (fileToCopy, cb) {
     }
 };
 
+var mkdirp = require('mkdirp');
+var checkFolderExist = function(folderPath) {
+    if (!fs.existsSync(folderPath)) {
+        mkdirp(path.dirname(folderPath), function (error) {
+            console.error("Could not create directory", error);
+        });
+    }
+};
+
 var writeContents = function (fileToCopy, options, cb) {
     var to = fileToCopy.to,
         intendedFrom = fileToCopy.intendedFrom;
     var contents = options.contents,
         uglified = options.uglified;
+
+    checkFolderExist();
     fs.writeFileSync(to, contents);
     if (settings.addLinkToSourceOfOrigin) {
         var sourceDetails = intendedFrom;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "chalk": "2.4.1",
     "cp-file": "5.0.0",
     "request": "2.87.0",
-    "uglify-js": "3.3.25"
+    "uglify-js": "3.3.25",
+    "mkdirp": "0.5.1"
   },
   "devDependencies": {
     "eslint": "4.19.1",


### PR DESCRIPTION
This plugin fails if the directory does not exist in the "to" property.

I added a check for it as well as it create the missing folder structure before it copy the asset over to there.